### PR TITLE
Z1 fixes

### DIFF
--- a/modes/index.lua
+++ b/modes/index.lua
@@ -5,7 +5,7 @@ modes = {
 	require "modes.lttp",
 	require "modes.lttp_randomizer",
 	require "modes.super_metroid",
-	require "modes.tloz_basic",
+	require "modes.tloz_all",
 	require "modes.tloz_progress",
-	require "modes.tloz_all"
+	require "modes.tloz_basic",
 }

--- a/modes/tloz_all.lua
+++ b/modes/tloz_all.lua
@@ -17,7 +17,7 @@ local base_spec = require('modes.tloz_progress')
 local spec = {
 	guid = "af791fc5-eeb2-49dc-985c-2ecba72157d9",
 	format = "1.1",
-	name = "The Legend of Zelda (sync everything)",
+	name = "The Legend of Zelda (sync most of the things)",
 	match = {"stringtest", addr=0xffeb, value="ZELDA"},
 
 	sync = {},

--- a/modes/tloz_all.lua
+++ b/modes/tloz_all.lua
@@ -17,7 +17,7 @@ local base_spec = require('modes.tloz_progress')
 local spec = {
 	guid = "377c5683-3cf5-4c56-a921-ab40257b2ec1",
 	format = "1.1",
-	name = "The Legend of Zelda (sync most of the things)",
+	name = "The Legend of Zelda (sync most things)",
 	match = {"stringtest", addr=0xffeb, value="ZELDA"},
 
 	sync = {},

--- a/modes/tloz_all.lua
+++ b/modes/tloz_all.lua
@@ -15,7 +15,7 @@ local math = require("math")
 local base_spec = require('modes.tloz_progress')
 
 local spec = {
-	guid = "af791fc5-eeb2-49dc-985c-2ecba72157d9",
+	guid = "377c5683-3cf5-4c56-a921-ab40257b2ec1",
 	format = "1.1",
 	name = "The Legend of Zelda (sync most of the things)",
 	match = {"stringtest", addr=0xffeb, value="ZELDA"},

--- a/modes/tloz_all.lua
+++ b/modes/tloz_all.lua
@@ -72,6 +72,25 @@ spec.sync[0x066F] = {
 	end
 }
 
+ -- bomb count, but we need to adjust how many bombs you actually have after
+ -- syncing (max out bombs on increase, reduce bombs on decrease)
+spec.sync[0x067C] = {kind="delta", deltaMin=1, deltaMax=255,
+	receiveTrigger=function(value, previousValue)
+		if value > previousValue then
+			-- we got an increase in bombs, set bomb count to the same thing and print out the bomb upgrade count
+			memory.writebyte(0x0658, value)
+			message("Partner got a bomb upgrade of " .. pluralMessage(value - previousValue, "bomb"))
+		else
+			-- we got a decrease in bombs so clamp our count and print out that we lost a bomb
+			local oldBombCount = memory.readbyte(0x0658)
+			if oldBombCount > value then
+				memory.writebyte(0x0658, value)
+			end
+			message("Partner chose to get rid of " .. pluralMessage(previousValue - value, "bomb"))
+		end
+	end
+}
+
 -- ow map open/get data is between 0x067f and 0x6fe (top left to bottom right)
 -- each tile has 0x80 set if it requires an item to open and is opened,
 -- 0x10 if the thing inside is obtainable and obtained. Tiles can be either or both of


### PR DESCRIPTION
- Makes health syncing a lot nicer.
- Syncs bomb upgrades and losses of max bombs and correctly clamp and bump up bomb counts in response.
- Change menu order of modes to reflect common usage. And rename sync everything to most of the things in preparation for a true sync everything mode.